### PR TITLE
Add logic to handle bad matched names.

### DIFF
--- a/backend/core_backend.py
+++ b/backend/core_backend.py
@@ -13,8 +13,8 @@ def match_titles_using_db_and_format(database: Database) -> list[str]:
 
     for i, item in enumerate(media_records):
         media_record = item
-        media_title = matched_titles[i]
-        media_year = matched_years[i]
+        media_title = "{None}" if matched_titles[i] is None else matched_titles[i]
+        media_year = "{None}" if matched_years[i] is None else matched_years[i]
 
         if database.is_tv_series:
             season_number = media_record.metadata.get("season")

--- a/pages/core.py
+++ b/pages/core.py
@@ -1,6 +1,7 @@
 import os.path
 
 from PySide6.QtCore import Qt, Slot
+from PySide6.QtGui import QColor
 from PySide6.QtWidgets import QListWidget, QMainWindow, QHBoxLayout, QVBoxLayout, QLabel, QWidget, QPushButton, \
     QDialog, QLineEdit, QBoxLayout, QListWidgetItem
 
@@ -155,6 +156,12 @@ class CoreRenamerWidget(QWidget):
             matched_media_titles = match_titles_using_db_and_format(database)
             for title in matched_media_titles:
                 list_item = QListWidgetItem()
+
+                # If any element (title, year, etc.) could not be found, highlight (light-red) the bad matched name.
+                if "{None}" in title:
+                    title = title.replace("{None}", "")
+                    list_item.setBackground(QColor(255, 80, 80))
+
                 list_item.setText(title)
                 right_box.addItem(list_item)
 


### PR DESCRIPTION
For instance, highlight names with missing titles or years as light-red.