### PR TITLE
Removed stubs and references to TheTVDB.

### DIFF
--- a/backend/api_key_config.py
+++ b/backend/api_key_config.py
@@ -22,14 +22,6 @@ def save_new_the_movie_db_key(api_key: str) -> None:
     api_key_config.set("the_movie_db", api_key)
 
 
-def retrieve_the_tv_db_key() -> str:
-    return api_key_config.get("the_tv_db", "")
-
-
-def save_new_the_tv_db_key(api_key: str) -> None:
-    api_key_config.set("the_tv_db", api_key)
-
-
 def retrieve_omdb_key() -> str:
     return api_key_config.get("omdb", "")
 

--- a/pages/core/match_options_widget.py
+++ b/pages/core/match_options_widget.py
@@ -103,8 +103,6 @@ class MatchOptionsWidget(QDialog):
         the_movie_db_button.setIcon(QIcon(QPixmap("resources/TheMovieDB Logo.svg")))
         the_movie_db_button.setObjectName("dbBtn")
 
-        the_tv_db_button = QPushButton("TheTVDB")
-
         tv_maze_db_button = QPushButton(" TVMaze ")
         tv_maze_db_button.clicked.connect(lambda: self.match_records_and_populate_output_box(
             TVMazePythonDB(self.media_records, self.is_tv_series), self.output_box))
@@ -118,7 +116,6 @@ class MatchOptionsWidget(QDialog):
         result: dict[QPushButton, list[str]] = {}
 
         result.update({the_movie_db_button: ["movie", "show"]})
-        result.update({the_tv_db_button: ["show"]})
         result.update({tv_maze_db_button: ["show"]})
         result.update({file_name_match_db_button: ["movie", "show"]})
 

--- a/tests/test_api_key_config.py
+++ b/tests/test_api_key_config.py
@@ -1,8 +1,8 @@
 import pytest
 
 from backend import api_key_config
-from backend.api_key_config import retrieve_the_movie_db_key, save_new_the_movie_db_key, retrieve_the_tv_db_key, \
-    save_new_the_tv_db_key, retrieve_omdb_key, save_new_omdb_key
+from backend.api_key_config import (retrieve_the_movie_db_key, save_new_the_movie_db_key, retrieve_omdb_key,
+                                    save_new_omdb_key)
 from backend.json_config import JSONConfig
 
 
@@ -40,19 +40,6 @@ def test_save_new_the_movie_db_key_new_value_retrieved(redirect_api_keys_file_pa
     retrieved_api_key = retrieve_the_movie_db_key()
 
     assert retrieved_api_key == "[This is my TheMovieDB key]"
-
-
-def test_retrieve_the_tv_db_key_default_value_retrieved(redirect_api_keys_file_path_to_temp_file):
-    default_api_key: str = retrieve_the_tv_db_key()
-
-    assert default_api_key == ""
-
-
-def test_save_new_the_tv_db_key_new_value_retrieved(redirect_api_keys_file_path_to_temp_file):
-    save_new_the_tv_db_key("[This is my TheTVDB key]")
-    retrieved_api_key = retrieve_the_tv_db_key()
-
-    assert retrieved_api_key == "[This is my TheTVDB key]"
 
 
 def test_retrieve_omdb_key_default_value_retrieved(redirect_api_keys_file_path_to_temp_file):


### PR DESCRIPTION
Without making a dedicated backend server to handle Simpler FileBot's TheTVDB API key, users would have to pay an $11.99 subscription which is not practical. TheTVDB will not be supported as a result.