### PR TITLE
Handles the case where the file to be renamed is held by another app.

### DIFF
--- a/backend/core_backend.py
+++ b/backend/core_backend.py
@@ -83,5 +83,10 @@ def perform_file_renaming(old_file_names: list[str], new_file_names: list[str]):
                          f"new_file_names has {len(new_file_names)} files...?")
 
     for old_file_name, new_file_name in zip(old_file_names, new_file_names):
-        # Raises an OSError if os.rename() fails.
-        os.rename(old_file_name, new_file_name)
+        # Other generic OSErrors are propagated to the caller.
+        try:
+            os.rename(old_file_name, new_file_name)
+        except PermissionError:
+            # Handle only the specific case where a file is being held by another process (Windows specific?).
+            # Current handling is just ignoring the specific file and moving onto the next one.
+            continue


### PR DESCRIPTION
Quick and dirty fix to #60.

We're just skipping the file that's causing the issue. However, we're silently handling this and the user just sees that the file wasn't properly renamed... Hopefully, this is a very limited case.

In the future, we might consider implementing exponential backoff or some other strategy that notifies the user of these events.