### PR TITLE
Fixed an issue with episode number parsing.

### DIFF
--- a/backend/media_record.py
+++ b/backend/media_record.py
@@ -76,6 +76,7 @@ class MediaRecord:
 
         # Setting commonly used values, otherwise, get from metadata.
         self.media_type: str | None = self.metadata.get("type")
+
         # self.title refers to the 'total' title. For movies, it's the movie title. For episodes, it's the series title.
         self.title: str | None = None
         raw_title: str | list | None = self.metadata.get("title")
@@ -86,6 +87,26 @@ class MediaRecord:
             self.title = raw_title
 
         self.year: int | None = self.metadata.get("year")
+
+        # Attempt to fill in 'season' or 'episode' if missing (This should not affect movies).
+        self._enrich_metadata_via_file_name()
+
+    def _enrich_metadata_via_file_name(self):
+        """
+        There are edge cases where the name of the folder (Which is used in guessing metadata) stops the
+        episode number or season number of a series episode from being parsed correctly.
+
+        This method attempts to analyze the metadata for a series episode using only the file name if
+        'season' or 'episode' is missing from the MediaRecord and fills them in."""
+        file_name_metadata: dict = guessit(self.file_name)
+
+        if self.metadata.get("season") is None:
+            if file_name_metadata.get("season") is not None:
+                self.metadata["season"] = file_name_metadata.get("season")
+
+        if self.metadata.get("episode") is None:
+            if file_name_metadata.get("episode") is not None:
+                self.metadata["episode"] = file_name_metadata.get("episode")
 
     def __str__(self):
         return self.file_name

--- a/tests/test_media_record.py
+++ b/tests/test_media_record.py
@@ -108,3 +108,9 @@ def test_get_all_season_numbers_success():
 
     assert 1 in season_numbers
     assert 3 in season_numbers
+
+
+def test_season_number_missing_episode_number_still_recognized():
+    media_record = MediaRecord("Chainsaw.Man.2022.S01.TrueHD.5.1/Chainsaw Man - 01 - Dog & Chainsaw.mkv")
+
+    assert media_record.metadata["episode"] == 1


### PR DESCRIPTION
Sometimes, guessit wouldn't parse the episode number at all due to name issues with the folder. We'll attempt to figure out the episode number using the filename as a backup.

Fixes #79.