### PR TITLE
Only use the extension from filename, not 'container' field from guessit.

### DIFF
--- a/backend/media_record.py
+++ b/backend/media_record.py
@@ -92,8 +92,8 @@ class MediaRecord:
         # Attempt to fill in 'season' or 'episode' if missing (This should not affect movies).
         self._enrich_metadata_via_file_name()
 
-        # Guessit does not work well with .txt files so, we'll grab it directly from the filename if missing.
-        self.container: str = self.metadata.get('container', Path(file_path).suffix.lstrip("."))
+        # Store the container from the original filename.
+        self.container: str = Path(file_path).suffix.lstrip(".")
 
     def _enrich_metadata_via_file_name(self):
         """

--- a/main.py
+++ b/main.py
@@ -53,7 +53,7 @@ class MainWindow(QMainWindow):
         self.menu.setSizePolicy(QSizePolicy.Policy.Fixed, QSizePolicy.Policy.Minimum)
 
         # Additional window setup.
-        self.setWindowTitle("Simpler FileBot v1.2.0")
+        self.setWindowTitle("Simpler FileBot v1.2.1")
         self.setWindowIcon(QIcon(QPixmap("resources/Alternative App Logo.png")))
 
         # Set the main application to start at a percentage of the screen's size.


### PR DESCRIPTION
There would be rare cases where the container field would contain multiple strings/containers, e.g., mpeg & mkv (Bad guessit analysis). Instead of relying on the container field, we'll just use the .extension from the original filename (Which we should have been using in the first place.