### PR TITLE
Support portable mode

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,6 @@
 /dist/
 /build/
 **/__pycache__/
+api_keys.json
+formats.json
+settings.json

--- a/backend/json_config.py
+++ b/backend/json_config.py
@@ -3,12 +3,20 @@ from json import JSONDecodeError
 from pathlib import Path
 
 from platformdirs import user_data_dir
-
+from backend.utils import is_portable
 
 class JSONConfig:
     """Handle one JSON config file with sensible defaults."""
     def __init__(self, filename: str, defaults: dict):
-        self.path = Path(user_data_dir(appauthor=False, appname="Simpler FileBot")) / filename
+        local_dir = Path.cwd()
+
+        if is_portable():
+            # Use the local folder if in portable mode.
+            self.path = local_dir / filename
+        else:
+            # Otherwise use the standard system path.
+            self.path = Path(user_data_dir(appauthor=False, appname="Simpler FileBot")) / filename
+
         self.defaults = defaults
         self._ensure_exists()
 

--- a/backend/utils.py
+++ b/backend/utils.py
@@ -3,7 +3,19 @@ import os
 
 def resource_path(relative_path):
     """ Get absolute path to resource, works for dev and for PyInstaller """
-    # If sys._MEIPASS does not exist, the current directory is used
+    # If sys._MEIPASS does not exist, the current directory is used.
     base_path = getattr(sys, '_MEIPASS', os.path.abspath(".")) # pylint: disable=no-member,protected-access
 
     return os.path.join(base_path, relative_path)
+
+def is_portable():
+    # Check, if name contain "portable".
+    try:
+        # pylint: disable=import-outside-toplevel
+        import build_constants
+        if getattr(build_constants, "IS_PORTABLE", False):
+            return True
+    except ImportError:
+        pass
+
+    return False

--- a/main.spec
+++ b/main.spec
@@ -15,7 +15,13 @@ import os
 # Gets the path to the folder where this .spec file is located
 work_dir = os.path.abspath(os.getcwd())
 
-a = Analysis(
+def create_constants_file(is_portable):
+    with open("build_constants.py", "w") as f:
+        f.write(f"IS_PORTABLE = {is_portable}")
+
+def get_analysis(is_portable):
+    create_constants_file(is_portable)
+    return Analysis(
     [os.path.join(work_dir, 'main.py')],
     pathex=[work_dir],
     binaries=binaries,
@@ -27,14 +33,16 @@ a = Analysis(
     excludes=['PySide6.QtWebEngineCore', 'PySide6.QtWebEngineWidgets', 'PySide6.Qt3DCore', 'PySide6.Qt3DRender', 'PySide6.QtCharts', 'PySide6.QtDataVisualization', 'PySide6.QtBluetooth', 'PySide6.QtMultimedia', 'PySide6.QtQuick', 'PySide6.QtNetwork'],
     noarchive=False,
     optimize=0,
-)
-pyz = PYZ(a.pure)
+    )
 
-exe = EXE(
-    pyz,
-    a.scripts,
-    a.binaries,
-    a.datas,
+# STANDARD Release
+a_port = get_analysis(is_portable=False)
+pyz_port = PYZ(a_port.pure)
+exe_port = EXE(
+    pyz_port,
+    a_port.scripts,
+    a_port.binaries,
+    a_port.datas,
     [],
     name='Simpler-FileBot',
     debug=False,
@@ -50,3 +58,32 @@ exe = EXE(
     codesign_identity=None,
     entitlements_file=None,
 )
+
+# PORTABLE Release
+a_port = get_analysis(is_portable=True)
+pyz_port = PYZ(a_port.pure)
+exe_port = EXE(
+    pyz_port,
+    a_port.scripts,
+    a_port.binaries,
+    a_port.datas,
+    [],
+    name='Simpler-FileBot-Portable',
+    debug=False,
+    bootloader_ignore_signals=False,
+    strip=False,
+    upx=True,
+    upx_exclude=[],
+    runtime_tmpdir=None,
+    console=False,
+    disable_windowed_traceback=False,
+    argv_emulation=False,
+    target_arch=None,
+    codesign_identity=None,
+    entitlements_file=None,
+)
+
+# --- CLEANUP ---
+# remove TEMP after build.
+if os.path.exists("build_constants.py"):
+    os.remove("build_constants.py")


### PR DESCRIPTION
Enable portable mode by having JSONConfig prefer the current working directory when a .portable flag file exists. Add .portable.readme.txt explaining how to enable portable mode. This allows the app to save settings to the CWD for portable use instead of the system user data directory.

 Mainly for use with binary, but works for "source" run as well.

https://github.com/StrawberryStego/Simpler-FileBot/issues/140